### PR TITLE
Add statistical analysis and LOSO classification modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,13 @@ Reference implementation of
 > [doi:10.1109/JBHI.2024.3405975](https://doi.org/10.1109/JBHI.2024.3405975)
 > - [IEEE Xplore](https://ieeexplore.ieee.org/document/10539177)
 
-This repository contains **only** the code needed to:
+This repository contains the code needed to:
 
 1. Build an EDA-graph from an electrodermal-activity signal
    (Section II-B and II-C of the paper).
 2. Extract the **58 graph / node / edge-level features** of Table II.
-
-It does **not** include classification, statistical-analysis or
-plotting utilities - those live outside this package and the
-published results in the paper are the reference.
+3. Run the **statistical analysis** (Section II-E) and
+   **Leave-One-Subject-Out classification** (Section II-F / Table IV).
 
 ![Step-by-step EDA-graph construction](Paper_Figures/Fig_2_step_by_step_graph.jpg)
 
@@ -36,10 +34,12 @@ pip install -e .
 
 ## 2. Run on a CASE-formatted dataset
 
-```bash
-python scripts/extract_features.py \
-    --data-root /path/to/CASE/interpolated \
-    --output EDA_graph_features.csv \
+### 2.1 Feature extraction
+
+```cmd
+python scripts\extract_features.py ^
+    --data-root "E:\OneDrive\Research\emotion_graph\Data\data\interpolated" ^
+    --output EDA_graph_features.csv ^
     --n-jobs -1
 ```
 
@@ -53,6 +53,36 @@ subject, <58 graph features>, valence, arousal, class
 where `<58 graph features>` is the list exported as
 `edagraph.features.GRAPH_FEATURE_NAMES` (see
 `edagraph/features/graph_features.py`).
+
+### 2.2 Statistical analysis (Section II-E)
+
+Anderson-Darling normality per class, Kruskal-Wallis H across classes,
+Dunn post-hoc with Holm-Bonferroni at `alpha = 0.005`:
+
+```cmd
+python scripts\run_statistics.py ^
+    --features EDA_graph_features.csv ^
+    --output-dir results\stats ^
+    --top-k 5
+```
+
+Outputs: `kruskal_wallis.csv`, `anderson_darling.csv` and one
+`dunn_<feature>.csv` per top-K feature.
+
+### 2.3 LOSO classification (Section II-F, Table IV)
+
+Eight classifiers (Naive Bayes, KNN, Random Forest, AdaBoost, Gradient
+Boosting, Decision Tree, SVM-RBF, Bagging Ensemble) with grid-search
+hyper-parameters matching Table IV, optional `SelectKBest`
+(ANOVA F-value, Section II-G):
+
+```cmd
+python scripts\run_classification.py ^
+    --features EDA_graph_features.csv ^
+    --k-best 5 ^
+    --output results\classification.csv ^
+    --n-jobs -1
+```
 
 ## 3. Use from Python
 
@@ -168,9 +198,13 @@ eda-graph/
 │   ├── features/
 │   │   └── graph_features.py     58 EDA-graph features (Table II)
 │   ├── dataset.py                CASE-format loader
-│   └── pipeline.py               Joblib-parallel batch extraction
+│   ├── pipeline.py               Joblib-parallel batch extraction
+│   ├── stats.py                  Anderson-Darling / Kruskal-Wallis / Dunn + Holm (Section II-E)
+│   └── experiments.py            LOSO classification (Section II-F, Table IV)
 ├── scripts/
-│   └── extract_features.py       CLI: folder -> features CSV
+│   ├── extract_features.py       CLI: folder -> features CSV
+│   ├── run_statistics.py         CLI: features CSV -> stat tables
+│   └── run_classification.py     CLI: features CSV -> LOSO summary
 ├── tests/test_pipeline.py        Smoke test on a synthetic signal
 ├── config.yaml                   Default Config serialised to YAML
 ├── requirements.txt / setup.py   Install recipe

--- a/edagraph/__init__.py
+++ b/edagraph/__init__.py
@@ -6,14 +6,12 @@ Mercado-Diaz, L. R., Veeranki, Y. R., Marmolejo-Ramos, F., & Posada-Quintero, H.
 EDA-Graph: Graph Signal Processing of Electrodermal Activity for Emotional States Detection.
 IEEE Journal of Biomedical and Health Informatics. https://doi.org/10.1109/JBHI.2024.3405975
 
-This package only contains the code required to
-1. turn an EDA segment into an EDA-graph (quantisation + k-NN) and
-2. extract the 58 graph / node / edge-level features described in Table II
-   of the paper.
+Three building blocks are exposed:
 
-No classification, statistics or plotting utilities are provided here -
-those belong to the downstream analysis scripts used to produce the
-published results.
+1. EDA-graph construction (Sections II-B and II-C).
+2. Extraction of the 58 graph / node / edge-level features (Table II).
+3. Statistical analysis (Section II-E) and Leave-One-Subject-Out
+   classification (Section II-F) of the extracted features.
 """
 from .config import Config, CASE_CLASS_MAP, CASE_VIDEO_CLASSES
 from .preprocessing import preprocess_eda, segment_signal, label_window
@@ -26,6 +24,8 @@ from .graph import build_eda_graph, knn_graph_from_points
 from .features import FEATURE_LEVELS, GRAPH_FEATURE_NAMES, extract_graph_features
 from .pipeline import EDAGraphPipeline
 from .dataset import load_case_subject, iter_case_windows
+from .stats import anderson_darling_by_class, kruskal_wallis, dunn_posthoc
+from .experiments import run_loso_classification
 
 __all__ = [
     "Config",
@@ -45,6 +45,10 @@ __all__ = [
     "EDAGraphPipeline",
     "load_case_subject",
     "iter_case_windows",
+    "anderson_darling_by_class",
+    "kruskal_wallis",
+    "dunn_posthoc",
+    "run_loso_classification",
 ]
 
 __version__ = "1.0.0"

--- a/edagraph/experiments.py
+++ b/edagraph/experiments.py
@@ -1,0 +1,188 @@
+"""Leave-One-Subject-Out classification (Section II-F and Table IV).
+
+The public API is :func:`run_loso_classification`: given a tidy feature
+DataFrame (columns must include ``subject`` and ``class``) it runs a
+LOSO cross-validation with eight classifiers, each wrapped in a grid
+search with hyper-parameters taken from Table IV of the paper.
+
+ANOVA F-value feature ranking (Section II-G) is optionally applied via
+``k_best`` (Table: top-K features with the highest score).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+from joblib import Parallel, delayed
+from sklearn.ensemble import (
+    AdaBoostClassifier,
+    BaggingClassifier,
+    GradientBoostingClassifier,
+    RandomForestClassifier,
+)
+from sklearn.feature_selection import SelectKBest, f_classif
+from sklearn.metrics import (
+    accuracy_score,
+    balanced_accuracy_score,
+    classification_report,
+    f1_score,
+)
+from sklearn.model_selection import GridSearchCV, GroupKFold
+from sklearn.naive_bayes import GaussianNB
+from sklearn.neighbors import KNeighborsClassifier
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+from sklearn.svm import SVC
+from sklearn.tree import DecisionTreeClassifier
+
+
+def _default_classifiers(random_state: int = 42) -> Dict[str, Tuple[Any, Dict[str, list]]]:
+    """Classifiers + hyper-parameter grids from Table IV of the paper."""
+    return {
+        "nb": (GaussianNB(), {"clf__var_smoothing": [1e-6, 1e-5, 1e-4]}),
+        "knn": (
+            KNeighborsClassifier(),
+            {
+                "clf__n_neighbors": [1, 2, 3, 4, 5],
+                "clf__weights": ["uniform", "distance"],
+                "clf__p": [1, 2],
+            },
+        ),
+        "rf": (
+            RandomForestClassifier(random_state=random_state, n_jobs=1),
+            {
+                "clf__n_estimators": [100, 200],
+                "clf__max_depth": [20, 30],
+                "clf__random_state": [42],
+            },
+        ),
+        "adaboost": (
+            AdaBoostClassifier(random_state=random_state),
+            {"clf__n_estimators": [50, 100, 150], "clf__learning_rate": [0.1, 0.5]},
+        ),
+        "gb": (
+            GradientBoostingClassifier(random_state=random_state),
+            {
+                "clf__n_estimators": [50, 100],
+                "clf__learning_rate": [0.1, 1.0],
+                "clf__max_depth": [40, 60],
+            },
+        ),
+        "dt": (
+            DecisionTreeClassifier(random_state=random_state),
+            {
+                "clf__max_depth": [10, 30],
+                "clf__min_samples_split": [2, 10],
+                "clf__random_state": [42],
+            },
+        ),
+        "svm": (
+            SVC(random_state=random_state),
+            {"clf__C": [1, 10, 100], "clf__gamma": [0.1, 1, 10], "clf__kernel": ["rbf"]},
+        ),
+        "bagging": (
+            BaggingClassifier(random_state=random_state, n_jobs=1),
+            {
+                "clf__n_estimators": [50, 100, 500],
+                "clf__max_samples": [0.3, 0.5, 1.0],
+                "clf__max_features": [0.3, 0.5, 0.7, 1.0],
+                "clf__bootstrap": [True, False],
+            },
+        ),
+    }
+
+
+@dataclass
+class LOSOResult:
+    classifier: str
+    accuracy: float
+    balanced_accuracy: float
+    macro_f1: float
+    weighted_f1: float
+    report: str
+
+
+def _fit_and_predict_fold(clf, params, X_tr, y_tr, X_te, y_te, inner_cv):
+    pipe = Pipeline([("scaler", StandardScaler()), ("clf", clf)])
+    gs = GridSearchCV(pipe, params, cv=inner_cv, n_jobs=1, scoring="balanced_accuracy")
+    gs.fit(X_tr, y_tr)
+    return y_te, gs.best_estimator_.predict(X_te)
+
+
+def run_loso_classification(
+    df: pd.DataFrame,
+    feature_cols: Sequence[str],
+    class_col: str = "class",
+    group_col: str = "subject",
+    k_best: int | None = None,
+    classifiers: Dict[str, Tuple[Any, Dict[str, list]]] | None = None,
+    inner_cv: int = 3,
+    n_jobs: int = -1,
+    verbose: int = 1,
+) -> Tuple[pd.DataFrame, Dict[str, LOSOResult]]:
+    """LOSO cross-validation with grid-searched pipelines.
+
+    Parameters
+    ----------
+    df : DataFrame
+        Must contain ``feature_cols``, ``class_col`` and ``group_col``.
+    k_best : int or None
+        If set, run ``SelectKBest(f_classif, k=k_best)`` upstream
+        (Section II-G of the paper).
+    inner_cv : int
+        Inner CV folds for the grid search on the training set.
+    n_jobs : int
+        Parallelism across subjects.
+    """
+    classifiers = classifiers or _default_classifiers()
+    X_full = df[list(feature_cols)].astype(np.float64).to_numpy()
+    y = df[class_col].to_numpy()
+    groups = df[group_col].to_numpy()
+
+    if k_best and k_best < X_full.shape[1]:
+        selector = SelectKBest(f_classif, k=k_best).fit(X_full, y)
+        X = X_full[:, selector.get_support()]
+        selected = [feature_cols[i] for i, b in enumerate(selector.get_support()) if b]
+    else:
+        X = X_full
+        selected = list(feature_cols)
+
+    unique_subjects = np.unique(groups)
+    splitter = GroupKFold(n_splits=len(unique_subjects))
+
+    results: Dict[str, LOSOResult] = {}
+    for name, (clf, params) in classifiers.items():
+        fold_jobs = [
+            (clf, params, X[tr_idx], y[tr_idx], X[te_idx], y[te_idx])
+            for tr_idx, te_idx in splitter.split(X, y, groups)
+        ]
+        outputs = Parallel(n_jobs=n_jobs, verbose=verbose)(
+            delayed(_fit_and_predict_fold)(c, p, *rest, inner_cv) for c, p, *rest in fold_jobs
+        )
+        y_true = np.concatenate([o[0] for o in outputs])
+        y_pred = np.concatenate([o[1] for o in outputs])
+        results[name] = LOSOResult(
+            classifier=name,
+            accuracy=float(accuracy_score(y_true, y_pred)),
+            balanced_accuracy=float(balanced_accuracy_score(y_true, y_pred)),
+            macro_f1=float(f1_score(y_true, y_pred, average="macro")),
+            weighted_f1=float(f1_score(y_true, y_pred, average="weighted")),
+            report=classification_report(y_true, y_pred, zero_division=0),
+        )
+
+    summary = pd.DataFrame(
+        [
+            {
+                "classifier": r.classifier,
+                "accuracy": r.accuracy,
+                "balanced_accuracy": r.balanced_accuracy,
+                "macro_f1": r.macro_f1,
+                "weighted_f1": r.weighted_f1,
+            }
+            for r in results.values()
+        ]
+    ).sort_values("balanced_accuracy", ascending=False)
+    summary.attrs["selected_features"] = selected
+    return summary, results

--- a/edagraph/stats.py
+++ b/edagraph/stats.py
@@ -1,0 +1,106 @@
+"""Statistical analysis (Section II-E of the paper).
+
+1. Anderson-Darling normality test per feature and class.
+2. Kruskal-Wallis one-way ANOVA on ranks: features with ``p < 0.05``
+   advance to post-hoc.
+3. Dunn pair-wise post-hoc with Holm-Bonferroni correction. The paper
+   treats a pair as significant when the corrected ``p < 0.005``.
+
+An optional Benjamini-Hochberg FDR step is exposed but **off** by
+default to match the paper's protocol.
+"""
+from __future__ import annotations
+
+from typing import Dict, Sequence
+
+import numpy as np
+import pandas as pd
+from scipy.stats import anderson, kruskal
+from statsmodels.stats.multitest import multipletests
+
+
+def anderson_darling_by_class(
+    df: pd.DataFrame,
+    features: Sequence[str],
+    class_col: str = "class",
+    alpha: float = 0.05,
+) -> pd.DataFrame:
+    """Anderson-Darling normality test per feature and class.
+
+    The critical value for ``alpha = 0.05`` sits at index 2 of the
+    ``critical_values`` array returned by :func:`scipy.stats.anderson`.
+    """
+    rows = []
+    idx_alpha = {0.15: 0, 0.10: 1, 0.05: 2, 0.025: 3, 0.01: 4}.get(alpha, 2)
+    for feat in features:
+        for cls in sorted(df[class_col].unique()):
+            data = df.loc[df[class_col] == cls, feat].dropna().to_numpy()
+            if data.size < 8:
+                rows.append((feat, int(cls), np.nan, np.nan, False))
+                continue
+            res = anderson(data, dist="norm")
+            stat = float(res.statistic)
+            crit = float(res.critical_values[idx_alpha])
+            rows.append((feat, int(cls), stat, crit, stat < crit))
+    return pd.DataFrame(rows, columns=["feature", "class", "statistic", "critical", "is_normal"])
+
+
+def kruskal_wallis(
+    df: pd.DataFrame, features: Sequence[str], class_col: str = "class"
+) -> pd.DataFrame:
+    """Kruskal-Wallis H-test across all classes for each feature."""
+    rows = []
+    classes = sorted(df[class_col].unique())
+    for feat in features:
+        groups = [df.loc[df[class_col] == c, feat].dropna().to_numpy() for c in classes]
+        groups = [g for g in groups if g.size > 0]
+        if len(groups) < 2:
+            rows.append((feat, np.nan, np.nan))
+            continue
+        h, p = kruskal(*groups)
+        rows.append((feat, float(h), float(p)))
+    return pd.DataFrame(rows, columns=["feature", "H", "p_value"])
+
+
+def dunn_posthoc(
+    df: pd.DataFrame,
+    features: Sequence[str],
+    class_col: str = "class",
+    p_adjust: str = "holm",
+    alpha: float = 0.005,
+    apply_fdr: bool = False,
+    fdr_method: str = "fdr_bh",
+) -> Dict[str, pd.DataFrame]:
+    """Per-feature Dunn post-hoc with Holm-Bonferroni correction.
+
+    Parameters
+    ----------
+    p_adjust : str
+        Correction method passed to :func:`scikit_posthocs.posthoc_dunn`.
+        The paper uses Holm-Bonferroni (``"holm"``).
+    alpha : float
+        Threshold used for the ``significant`` attribute (paper: ``0.005``).
+    apply_fdr : bool
+        If ``True``, also apply a Benjamini-Hochberg FDR correction on
+        top of the Dunn/Holm p-values (off by default).
+
+    Returns
+    -------
+    dict ``{feature: DataFrame}``
+        Each DataFrame is the class-by-class p-value matrix. A
+        boolean ``significant = p < alpha`` matrix is stored in
+        ``df.attrs['significant']``.
+    """
+    import scikit_posthocs as sp  # lazy import - optional dependency
+
+    out: Dict[str, pd.DataFrame] = {}
+    for feat in features:
+        sub = df[[feat, class_col]].dropna()
+        posthoc = sp.posthoc_dunn(sub, val_col=feat, group_col=class_col, p_adjust=p_adjust)
+        if apply_fdr:
+            p = posthoc.to_numpy().ravel()
+            _, p_corr, _, _ = multipletests(p, method=fdr_method)
+            posthoc.iloc[:, :] = p_corr.reshape(posthoc.shape)
+        posthoc.attrs["significant"] = posthoc < alpha
+        out[feat] = posthoc
+    return out

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ pandas>=2.0
 networkx>=3.0
 joblib>=1.2
 PyYAML>=6.0
+scikit-learn>=1.2
+statsmodels>=0.14
+scikit-posthocs>=0.8

--- a/scripts/run_classification.py
+++ b/scripts/run_classification.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+"""Run the Leave-One-Subject-Out classification experiment
+(Section II-F and Table IV of the paper).
+
+Example
+-------
+    python scripts/run_classification.py ^
+        --features EDA_graph_features.csv ^
+        --k-best 5 ^
+        --output results/classification.csv
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from edagraph.experiments import run_loso_classification
+
+
+def parse_args():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--features", required=True, help="CSV produced by extract_features.py")
+    ap.add_argument("--output", default=None, help="Path to write the summary CSV.")
+    ap.add_argument("--k-best", type=int, default=None, help="Select K-best features via ANOVA F-score.")
+    ap.add_argument("--class-col", default="class")
+    ap.add_argument("--group-col", default="subject")
+    ap.add_argument("--n-jobs", type=int, default=-1)
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    df = pd.read_csv(args.features)
+    drop_cols = {args.class_col, args.group_col, "valence", "arousal"}
+    feat_cols = [c for c in df.columns if c not in drop_cols]
+
+    summary, reports = run_loso_classification(
+        df,
+        feature_cols=feat_cols,
+        class_col=args.class_col,
+        group_col=args.group_col,
+        k_best=args.k_best,
+        n_jobs=args.n_jobs,
+    )
+
+    print("\n=== Summary ===")
+    print(summary.to_string(index=False))
+    if "selected_features" in summary.attrs:
+        print("\nSelected features:", summary.attrs["selected_features"])
+
+    for name, res in reports.items():
+        print(f"\n--- {name} ---")
+        print(res.report)
+
+    if args.output:
+        Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+        summary.to_csv(args.output, index=False)
+        print(f"\nWrote summary to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_statistics.py
+++ b/scripts/run_statistics.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+"""Run the Anderson-Darling / Kruskal-Wallis / Dunn + Holm-Bonferroni
+statistical pipeline (Section II-E of the paper).
+
+Example
+-------
+    python scripts/run_statistics.py ^
+        --features EDA_graph_features.csv ^
+        --output-dir results/stats ^
+        --top-k 5
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from edagraph.stats import anderson_darling_by_class, dunn_posthoc, kruskal_wallis
+
+
+def parse_args():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--features", required=True, help="CSV produced by extract_features.py")
+    ap.add_argument("--output-dir", default="results/stats")
+    ap.add_argument("--top-k", type=int, default=5, help="Top-K features by Kruskal-Wallis H.")
+    ap.add_argument("--class-col", default="class")
+    ap.add_argument("--alpha", type=float, default=0.005, help="Significance threshold (paper: 0.005).")
+    ap.add_argument("--apply-fdr", action="store_true", help="Also run BH-FDR on top of Holm.")
+    return ap.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    df = pd.read_csv(args.features)
+    feat_cols = [c for c in df.columns if c not in {args.class_col, "subject", "valence", "arousal"}]
+
+    kw = kruskal_wallis(df, feat_cols, class_col=args.class_col).sort_values("p_value")
+    top = kw.head(args.top_k)["feature"].tolist()
+
+    ad = anderson_darling_by_class(df, top, class_col=args.class_col)
+    dunn = dunn_posthoc(
+        df, top, class_col=args.class_col, alpha=args.alpha, apply_fdr=args.apply_fdr
+    )
+
+    out_dir = Path(args.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    kw.to_csv(out_dir / "kruskal_wallis.csv", index=False)
+    ad.to_csv(out_dir / "anderson_darling.csv", index=False)
+    for feat, table in dunn.items():
+        table.to_csv(out_dir / f"dunn_{feat}.csv")
+
+    print("\n=== Kruskal-Wallis (top 15) ===")
+    print(kw.head(15).to_string(index=False))
+    print("\n=== Anderson-Darling on top features ===")
+    print(ad.to_string(index=False))
+    print(f"\nWrote all tables to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="edagraph",
-    version="1.0.0",
+    version="1.1.0",
     description="EDA-Graph: Graph Signal Processing of Electrodermal Activity for Emotional States Detection.",
     long_description=Path("README.md").read_text(encoding="utf-8"),
     long_description_content_type="text/markdown",
@@ -19,10 +19,15 @@ setup(
         "networkx>=3.0",
         "joblib>=1.2",
         "PyYAML>=6.0",
+        "scikit-learn>=1.2",
+        "statsmodels>=0.14",
+        "scikit-posthocs>=0.8",
     ],
     entry_points={
         "console_scripts": [
             "edagraph-extract = scripts.extract_features:main",
+            "edagraph-stats = scripts.run_statistics:main",
+            "edagraph-classify = scripts.run_classification:main",
         ],
     },
     license="MIT",


### PR DESCRIPTION
## Summary

Adds the two remaining stages of the paper so the repository supports the full extraction → analysis → classification workflow:

- **`edagraph/stats.py`** — Anderson-Darling normality per feature/class, Kruskal-Wallis H across classes, Dunn post-hoc with Holm-Bonferroni at `alpha = 0.005` (Section II-E).
- **`edagraph/experiments.py`** — Leave-One-Subject-Out classification with eight grid-searched classifiers (Naive Bayes, KNN, Random Forest, AdaBoost, Gradient Boosting, Decision Tree, SVM-RBF, Bagging Ensemble), hyper-parameters from Table IV, optional `SelectKBest` ANOVA F-value ranking (Section II-F / II-G).
- **`scripts/run_statistics.py`** and **`scripts/run_classification.py`** — CLI wrappers.
- Console entry points: `edagraph-stats`, `edagraph-classify`.
- Requirements: `scikit-learn`, `statsmodels`, `scikit-posthocs`.
- README documents the three commands.

## Usage

```cmd
python scripts\extract_features.py     --data-root "...\CASE\interpolated" --output EDA_graph_features.csv --n-jobs -1
python scripts\run_statistics.py       --features EDA_graph_features.csv  --output-dir results\stats --top-k 5
python scripts\run_classification.py   --features EDA_graph_features.csv  --k-best 5 --output results\classification.csv --n-jobs -1
```

## Test plan

- [x] `pytest tests/` — 2/2 pass
- [x] `python -c "from edagraph import run_loso_classification, kruskal_wallis, dunn_posthoc"` — imports cleanly
- [ ] Run the three CLIs on the real CASE data


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mk3pe2MCXRjreuubARJE3d)_